### PR TITLE
Change webfinger content-type to application/jrd+json

### DIFF
--- a/webservice/src/webfinger.js
+++ b/webservice/src/webfinger.js
@@ -79,6 +79,6 @@ export async function handleWebfingerGETRequest(requestDATA) {
     hostname = resourceArray[1];
   
     const jsonData = '{"subject":"acct:' + query + '","aliases":["https://' + hostname + '/@' + username + '","https://' + hostname + '/users/' + username + '"],"links":[{"rel":"http://webfinger.net/rel/profile-page","type":"text/html","href":"https://' + hostname + '/@' + username + '"},{"rel":"self","type":"application/activity+json","href":"https://' + hostname + '/users/' + username + '"},{"rel":"http://ostatus.org/schema/1.0/subscribe","template":"https://' + hostname + '/authorize_interaction?uri={uri}"}]}';
-    return new Response(jsonData, {status: "200", headers: {"content-type": "application/json;charset=UTF-8"},
+    return new Response(jsonData, {status: "200", headers: {"content-type": "application/jrd+json;charset=UTF-8"},
     });
 }


### PR DESCRIPTION
Hello, I found this project just after setting up my WebFinger manually. But I switched to webfinger.io as it's really useful. Thank you for creating! 🙂

So I noticed that the current `winfinger.io/.well-known/webfinger` returns the JSON content with `content-type: application/json`. But according to the spec, the media type used for WebFinger is `application/jrd+json`:

> The media type used for the JSON Resource Descriptor (JRD) is "application/jrd+json"

https://datatracker.ietf.org/doc/html/rfc7033#:~:text=The%20media%20type%20used%20for%20the%20JSON%0A%20%20%20Resource%20Descriptor%20(JRD)%20is%20%22application/jrd%2Bjson%22

You can also see the same `content-type` is used by https://mastodon.social/.well-known/webfinger?resource=acct:Mastodon@mastodon.social.

Practically, it looks like there's no issue to query the user at least for mastodon.social I tested but I think this change could prevent a potential incompatibility issue.