### PR TITLE
feat: Replace `uuid` lib with node `crypto.randomUUID()`

### DIFF
--- a/webservice/package-lock.json
+++ b/webservice/package-lock.json
@@ -1,15 +1,12 @@
 {
   "name": "webservice",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "webservice",
-      "version": "0.0.0",
-      "dependencies": {
-        "uuid": "^9.0.0"
-      },
+      "version": "0.1.0",
       "devDependencies": {
         "wrangler": "2.1.10"
       }
@@ -1426,14 +1423,6 @@
       "integrity": "sha512-DOE84vZT2fEcl9gqCUTcnAw5ZY5Id55ikUcziSUntuEFL3pRvavg5kwDmTEUJkeCHInTlV/HexFomgYnzO5kdQ==",
       "dev": true
     },
-    "node_modules/uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/validate-npm-package-name": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-4.0.0.tgz",
@@ -2497,11 +2486,6 @@
       "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-4.0.3.tgz",
       "integrity": "sha512-DOE84vZT2fEcl9gqCUTcnAw5ZY5Id55ikUcziSUntuEFL3pRvavg5kwDmTEUJkeCHInTlV/HexFomgYnzO5kdQ==",
       "dev": true
-    },
-    "uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
     },
     "validate-npm-package-name": {
       "version": "4.0.0",

--- a/webservice/package.json
+++ b/webservice/package.json
@@ -9,7 +9,5 @@
     "start": "wrangler dev",
     "deploy": "wrangler publish"
   },
-  "dependencies": {
-    "uuid": "^9.0.0"
-  }
+  "dependencies": {}
 }

--- a/webservice/src/index.js
+++ b/webservice/src/index.js
@@ -10,8 +10,7 @@
 // Change to variable?
 let globalDomain = "webfinger.io";
 
-// npm install uuid
-import { v4 as uuidv4 } from 'uuid';
+import { randomUUID } from 'crypto';
 
 // Separate file to make updates easier
 import { getsecuritytxt } from "./securitytxt.js";
@@ -184,7 +183,7 @@ async function handleGETRequest(requestData) {
 	} 
   else if (requestURL.pathname === "/new") {
     let initial_data = {};
-    initial_data["uuid"] = uuidv4();
+    initial_data["uuid"] = randomUUID();
     htmlContent = gethtmlContentRegistration("newregistration", initial_data);
     return new Response(htmlContent, {status: "200", headers: {'content-type': 'text/html;charset=UTF-8'}});
 	} 

--- a/webservice/src/logicProcessing.js
+++ b/webservice/src/logicProcessing.js
@@ -1,9 +1,8 @@
+import { randomUUID } from 'crypto';
+
 // Processing content email/html
 import { gethtmlContentProcessing } from "./htmlContentProcessing.js"
 import { getemailContentProcessing } from "./emailContentProcessing.js"
-
-// npm install uuid
-import { v4 as uuidv4 } from 'uuid';
 
 // Processing email handler
 import { handleEmail } from "./emailHandler.js"
@@ -35,7 +34,7 @@ export async function readProcessingRequestBodyPOST(request) {
   }
 
   // Generate a unique ID early on, we'll need it in a few places (each record type)
-  uuid_value = uuidv4();
+  uuid_value = randomUUID();
 
   // The KV auth data is always the same, multiple records, e.g. email:, github:
   KVauthdata = {};


### PR DESCRIPTION
Hello! I found my way here because of the Open Source Security Podcast; Josh (whom I am fortunate to work with at Anchore) seemed indignant about the number of dependencies that might be hiding in this service, so I thought I'd take the opportunity to reduce it from 1 to 0

![troll](https://user-images.githubusercontent.com/3816327/232466389-21a32139-1227-40f4-9256-24b97b8177b5.jpeg)

This patch replaces the third party `uuid` library with node's native `crypto.randomUUID` function, which generates v4 UUIDs, which I think is the only use case in this service. I'm not super familiar with cloudflare workers, but https://developers.cloudflare.com/workers/runtime-apis/web-crypto/ seems to indicate this is supported

Linking the docs (https://nodejs.org/api/crypto.html#cryptorandomuuidoptions) too, in case you'd like to look further into this

