### PR TITLE
chore: add site-wide 'stale / rewrite planned' notice

### DIFF
--- a/webservice/src/htmlContentRegistration.js
+++ b/webservice/src/htmlContentRegistration.js
@@ -39,7 +39,18 @@ export function gethtmlContentRegistration(status, data) {
       </div>
     </div>
   </div>
-   
+
+  <div class="row">
+    <div class="column">
+      <div style="border: 2px solid #c0392b; background: #fdecea; color: #611a15; padding: 1rem 1.5rem; border-radius: 4px; margin: 0 0 2rem 0;">
+        <p style="margin-bottom: 0.5rem;"><strong>&#9888; This service is stale.</strong></p>
+        <p style="margin-bottom: 0;">webfinger.io has fallen out of date and several verification features are
+        currently non-functional. A complete rewrite and overhaul is planned, but there is
+        <strong>no ETA</strong> at this time. Existing verified WebFinger lookups continue to work.</p>
+      </div>
+    </div>
+  </div>
+
 
     
 


### PR DESCRIPTION
## Summary

Adds a prominent notice banner to the shared page header announcing that webfinger.io is stale, several features are non-functional, and a complete rewrite/overhaul is planned with **no ETA**.

- Lives in the shared `header` block, so it shows on all HTML pages (registration, verified, error).
- The machine-readable `/.well-known/webfinger` JSON endpoint does **not** use this template, so existing verified lookups keep resolving.

Verified via Node render: notice appears exactly once, above the form, and the page remains well-formed.

Refs #5