### PR TITLE
fix: use global crypto.randomUUID() (unbreak deploy)

### DIFF
--- a/webservice/src/index.js
+++ b/webservice/src/index.js
@@ -10,7 +10,9 @@
 // Change to variable?
 let globalDomain = "webfinger.io";
 
-import { randomUUID } from 'crypto';
+// randomUUID() is available as a global via the Workers Web Crypto API (crypto.randomUUID()),
+// so no import is needed. Importing from the Node "crypto" module would require the
+// nodejs_compat flag, which this Worker is not deployed with.
 
 // Separate file to make updates easier
 import { getsecuritytxt } from "./securitytxt.js";
@@ -183,7 +185,7 @@ async function handleGETRequest(requestData) {
 	} 
   else if (requestURL.pathname === "/new") {
     let initial_data = {};
-    initial_data["uuid"] = randomUUID();
+    initial_data["uuid"] = crypto.randomUUID();
     htmlContent = gethtmlContentRegistration("newregistration", initial_data);
     return new Response(htmlContent, {status: "200", headers: {'content-type': 'text/html;charset=UTF-8'}});
 	} 

--- a/webservice/src/logicProcessing.js
+++ b/webservice/src/logicProcessing.js
@@ -1,4 +1,5 @@
-import { randomUUID } from 'crypto';
+// randomUUID() is available as a global via the Workers Web Crypto API (crypto.randomUUID()),
+// so no import is needed (importing Node's "crypto" would require the nodejs_compat flag).
 
 // Processing content email/html
 import { gethtmlContentProcessing } from "./htmlContentProcessing.js"
@@ -34,7 +35,7 @@ export async function readProcessingRequestBodyPOST(request) {
   }
 
   // Generate a unique ID early on, we'll need it in a few places (each record type)
-  uuid_value = randomUUID();
+  uuid_value = crypto.randomUUID();
 
   // The KV auth data is always the same, multiple records, e.g. email:, github:
   KVauthdata = {};


### PR DESCRIPTION
The Worker is deployed with **no** `nodejs_compat` flag, so `import { randomUUID } from 'crypto'` (added in b8baeb5) fails to bundle — confirmed with both the pinned wrangler 2.1.10 and modern 4.x. This means the current `main` tree has not been deployable as-is.

Workers expose `crypto.randomUUID()` as a Web Crypto **global**, so this drops the Node import in `index.js` and `logicProcessing.js` and calls the global directly. Result: the tree bundles cleanly with **zero** change to the Worker's compatibility settings (dry-run verified, 73.71 KiB).

Refs #5