### PR TITLE
security.txt: RFC 9116 expiry + quarterly refresh policy

### DIFF
--- a/docs.webfinger.io/TODO.md
+++ b/docs.webfinger.io/TODO.md
@@ -44,6 +44,14 @@ Evaluated repositioning webfinger.io toward the AI-agent ecosystem. Declined:
       in the Worker.
 
 ### Security / hygiene
+- [ ] **Refresh `security.txt` `Expires` every 3 months** (calendar reminder needed —
+      not yet created). Each refresh sets the date a further 12 months out, so we
+      touch it 4x/year and it is never near expiry. RFC 9116 wants under a year;
+      annual renewal is too easy to forget, quarterly keeps a rhythm.
+      Field lives in `webservice/src/securitytxt.js`. Requires a deploy to take
+      effect. Next due: **2026-12-05** (set `Expires` to 2027-12-05).
+      Same treatment needed on other CSA properties — riskrubric.ai is currently
+      2050-01-01, cloudsecurityalliance.org expires 2027-01-01.
 - [ ] Secrets (DKIM private key, verification API token) are stored as **plaintext
       Worker vars**. Rotate and move to `wrangler secret put`.
 - [ ] Code relies on **implicit globals / non-strict mode** (see CLAUDE.md). The

--- a/webservice/src/securitytxt.js
+++ b/webservice/src/securitytxt.js
@@ -1,9 +1,15 @@
 
 // filename: ./src/securitytxt.js
+// RFC 9116 says Expires should be less than a year out. We refresh QUARTERLY,
+// each time setting it a year ahead, so the file is never close to expiring and
+// the task stays in a rhythm we actually notice. An annual renewal is too easy
+// to forget. Next refresh due 2026-12-05 -> set Expires to 2027-12-05.
 export function getsecuritytxt() {
     let htmlContent = `Contact: mailto:security@webfinger.io
-Expires: 2052-12-01T19:34:00.000Z
+Expires: 2027-09-05T00:00:00.000Z
 Canonical: https://webfinger.io/.well-known/security.txt
+Policy: https://cloudsecurityalliance.org/security
+Preferred-Languages: en
 `;
 return htmlContent;
 }


### PR DESCRIPTION
`Expires` was **2052-12-01** — about 26 years out. RFC 9116 says it should be less than a year ahead, so the file was non-conformant, and a decades-out expiry reads to a researcher as a contact nobody maintains.

- `Expires` now **2027-09-05** (one year out, verified 365 days)
- Adds `Policy` and `Preferred-Languages`, present on the main CSA security.txt but missing here
- Records the refresh policy in `TODO.md`: **every 3 months, set the date 12 months out** — four touches a year keeps it in a rhythm rather than an annual thing that gets forgotten. Next due 2026-12-05.

The TODO also notes the calendar reminder still needs creating, and that riskrubric.ai (2050-01-01) needs the same fix.

Requires a deploy to take effect.