### PR TITLE
Final tidy: page copy and TODO accuracy

### DIFF
--- a/docs.webfinger.io/TODO.md
+++ b/docs.webfinger.io/TODO.md
@@ -44,16 +44,29 @@ Evaluated repositioning webfinger.io toward the AI-agent ecosystem. Declined:
       in the Worker.
 
 ### Security / hygiene
-- [ ] **Refresh `security.txt` `Expires` every 3 months** (calendar reminder needed —
-      not yet created). Each refresh sets the date a further 12 months out, so we
-      touch it 4x/year and it is never near expiry. RFC 9116 wants under a year;
-      annual renewal is too easy to forget, quarterly keeps a rhythm.
-      Field lives in `webservice/src/securitytxt.js`. Requires a deploy to take
-      effect. Next due: **2026-12-05** (set `Expires` to 2027-12-05).
-      Same treatment needed on other CSA properties — riskrubric.ai is currently
-      2050-01-01, cloudsecurityalliance.org expires 2027-01-01.
-- [ ] Secrets (DKIM private key, verification API token) are stored as **plaintext
-      Worker vars**. Rotate and move to `wrangler secret put`.
+- [x] **Refresh `security.txt` `Expires` every 3 months.** Recurring calendar
+      reminder created 2026-09-05, first firing 2026-12-07. Each refresh sets the
+      date a further 12 months out, so we touch it 4x/year and it is never near
+      expiry. RFC 9116 wants under a year; annual renewal is too easy to forget.
+      Field lives in `webservice/src/securitytxt.js`; requires a deploy to take
+      effect (see `DEPLOY.md`). Currently 2027-09-05.
+- [ ] Apply the same treatment to other CSA properties — riskrubric.ai is
+      currently 2050-01-01 (non-conformant), cloudsecurityalliance.org expires
+      2027-01-01. Both are outside this repo.
+- [x] **Secrets removed from `wrangler.toml` entirely** (2026-09-05). `DKIM_*` and
+      `API_*_VERIFICATION` were plaintext Worker vars; nothing in the bundle reads
+      them any more, so they were deleted rather than migrated. The config now holds
+      no secret material.
+      Context: the DKIM signing key for this domain had been publicly disclosed since
+      January 2023 in a fork of this repo that committed `wrangler.toml` before
+      `.gitignore` covered it. The `mailchannels._domainkey.webfinger.io` DNS record
+      has been deleted, so the disclosed key can no longer authenticate anything, and
+      `relay.mailchannels.net` was dropped from SPF. Mail now goes solely via Google
+      Workspace under the `google` selector.
+- [ ] If a secret is ever needed again, use `wrangler secret put` — never
+      `[env.production.vars]`, which is a plaintext file that can be committed.
 - [ ] Code relies on **implicit globals / non-strict mode** (see CLAUDE.md). The
       rewrite should use explicit declarations / ES modules.
-- [ ] Remove leftover debug markers (e.g. `+ "1234"` appended to error pages).
+- [ ] Remove leftover debug markers (e.g. `+ "1234"` in `logicConfirmation.js`).
+      Not currently shipped — that module is no longer imported by `index.js` since
+      signups closed — but it should go in the rewrite.

--- a/webservice/src/htmlContentRegistration.js
+++ b/webservice/src/htmlContentRegistration.js
@@ -212,9 +212,7 @@ htmlContent["registration"] = `
     <p><strong>webfinger.io</strong> is a public WebFinger service that maps an email address to a Mastodon ID,
     so people can find you by your email address and see that the link is trustworthy.</p>
 
-    <p><strong>New registrations are closed</strong> while we evaluate how to renew and refresh this project.
-    Existing registrations will continue to work and are served as normal. Social-media verification
-    (Twitter, Reddit and GitHub) has been retired; see
+    <p>Social-media verification (Twitter, Reddit and GitHub) has been retired; see
     <a href="https://github.com/cloudsecurityalliance/webfinger.io/blob/main/docs.webfinger.io/social-verification-retired.md">the write-up</a>
     for why.</p>
 
@@ -240,12 +238,12 @@ htmlContent["registration"] = `
     
     <h2>Security and anti-abuse</h2>
     
-    <p>We've taken several steps to ensure this service is safe and respects users privacy. We only ask for the data you want us to serve 
-    (your email and Mastodon ID). We support email addresses deleting their record, and marking themselves as "do not contact". We 
-    also support administrative blocklists for both emails and Mastodon IDs, e.g. we can block "example.org" if you do not want your users 
-    to use this service, contact us at admin at webfinger.io. We also restrict the length and format of emails and Mastodon IDs to 128 
-    characters. This service runs on Cloudflare Workers and KV store, which logs data such as IP addresses
-    accessing the service. No email is currently sent, as registrations are closed.</p>
+    <p>We've taken several steps to ensure this service is safe and respects users' privacy. We only ask for the data you want us
+    to serve (your email and Mastodon ID), and we restrict the length and format of emails and Mastodon IDs to 128 characters. We
+    support administrative blocklists for both emails and Mastodon IDs &mdash; for example we can block "example.org" if you do not
+    want your users to use this service. Record deletion, "do not contact" requests and blocklist requests are all handled by emailing
+    <a href="mailto:admin@webfinger.io">admin@webfinger.io</a>. This service runs on Cloudflare Workers and KV store, which logs data
+    such as IP addresses accessing the service. No email is currently sent, as registrations are closed.</p>
     
     <p>webfinger.io is a <a href="https://cloudsecurityalliance.org/">Cloud Security Alliance</a> Research project. It is available in GitHub at
     <a href="https://github.com/cloudsecurityalliance/webfinger.io">https://github.com/cloudsecurityalliance/webfinger.io</a>.</p>


### PR DESCRIPTION
Closing out the remaining loose ends.

**Page**
- The banner and the paragraph below it were saying the same thing twice — the form used to sit between them, so it wasn't obvious until the form was removed. Trimmed the paragraph to just its unique content.
- The anti-abuse section still claimed self-service record deletion and "do not contact", neither of which exists now. Rewritten to point at `admin@webfinger.io`, and de-duplicated (it mentioned that address twice in different forms).

**TODO**
- Quarterly `security.txt` refresh: recurring calendar reminder now created, first firing 2026-12-07. Marked done, with the cross-property follow-up split into its own item.
- Secrets: recorded that they were *deleted* rather than migrated, plus the DKIM disclosure and its remediation, so the history is legible to whoever does the rewrite.
- Debug marker: noted its module is no longer shipped.

Copy and docs only.